### PR TITLE
Replaced React VR with React XR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ AR.js https://developer.vuforia.com/downloads/sdk \
 BabylonJS https://www.babylonjs.com/ \
 JavaScript https://www.javascript.com/ \
 PrimroseVR https://www.primrosevr.com/ \
-React VR https://www.npmjs.com/package/react-vr \
+React XR https://github.com/pmndrs/react-xr \
 Reality Composer https://apps.apple.com/us/app/reality-composer/id1462358802 \
 RealityKit https://developer.apple.com/documentation/realitykit \
 threeJS https://github.com/mrdoob/three.js/


### PR DESCRIPTION
React VR is no longer supported by facebook.